### PR TITLE
fix the zotero select url generation bug for group libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ The result file(docx) is as follows:
 > [!warning]
 > Citekeys containing `#` `^` `[` `]` `|` `\` `/` `:` will be skipped as these characters are not allowed in Obsidian filenames. Check the console log if items are missing.
 
+## 📚 Group libraries support
+
+By default, the Zotero link in each literature note uses `zotero://select/items/@citekey`, which only works for personal libraries. If you use Zotero **group libraries**, you need to add the following postscript in Better BibTeX to export the library URI:
+
+```javascript
+if (Translator.BetterCSLJSON) {
+  csl.zotero_uri = zotero.uri;
+}
+```
+
+When `zotero_uri` is present and contains a group ID, the plugin automatically generates the correct link: `zotero://select/groups/{groupId}/items/@citekey`. No additional plugin settings are required.
+
 ## ➕ Additional options
 
 > [!tip]
@@ -140,6 +152,7 @@ if (Translator.BetterCSLJSON) {
   });
 
   csl.collections = collections;
+  csl.zotero_uri = zotero.uri;
 }
 ```
 
@@ -168,7 +181,9 @@ if (Translator.BetterCSLJSON) {
     if (p) collections.push(library + ": " + p);
   });
 
+  
   csl.collections = collections.length > 0 ? collections : [library];
+  csl.zotero_uri = zotero.uri;
 }
 ```
 

--- a/src/utils/updateFrontMatter.ts
+++ b/src/utils/updateFrontMatter.ts
@@ -60,7 +60,10 @@ export async function updateFrontMatter(
 		}
 		fm.journal = item['container-title'];
 		fm.doi = item['DOI'] ? `https://doi.org/${item['DOI']}` : "";
-		fm.zotero = "zotero://select/items/@" + item['id'];
+		const groupMatch = item['zotero_uri']?.match(/\/groups\/(\d+)/);
+		fm.zotero = groupMatch
+			? `zotero://select/groups/${groupMatch[1]}/items/@${item['id']}`
+			: `zotero://select/items/@${item['id']}`;
 		if (settings.includeBibliography && item['_source_files'] && Array.isArray(item['_source_files'])) {
 			fm.bibliography = item['_source_files'];
 		} else {


### PR DESCRIPTION
Hi! Sorry the bug from my last PR.

## 📚 Group libraries support

By default, the Zotero link in each literature note uses `zotero://select/items/@citekey`, which only works for personal libraries. If you use Zotero **group libraries**, you need to add the following postscript in Better BibTeX to export the library URI:

```javascript
if (Translator.BetterCSLJSON) {
  csl.zotero_uri = zotero.uri;
}
```

When `zotero_uri` is present and contains a group ID, the plugin automatically check the type(personal, or groups) of any libraries and generates the correct link: `zotero://select/groups/{groupId}/items/@citekey`. No additional plugin settings are required.


I already update the readme. providing the backward compatibility too